### PR TITLE
Check the correct index of the string when attempting to verify https

### DIFF
--- a/pysteamsignin/steamsignin.py
+++ b/pysteamsignin/steamsignin.py
@@ -56,7 +56,7 @@ class SteamSignIn():
             logger.critical(errMessage)
             raise ValueError(errMessage)
 
-        if responseURL[5] != 's':
+        if responseURL[4] != 's':
             logger.warning('https isn\'t being used! Is this intentional?')
 
         authParameters = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="steamsignin",
-    version="1.0.0",
+    version="1.0.1",
     author="TeddiO",
     author_email="",
     description="OpenID 2.0 sign in for Steam",


### PR DESCRIPTION
Check index position 4 instead of 5 when checking for `https`. 


Closes https://github.com/TeddiO/pySteamSignIn/issues/6