### PR TITLE
Bump pypi version + minor bugfix

### DIFF
--- a/pysteamsignin/steamsignin.py
+++ b/pysteamsignin/steamsignin.py
@@ -57,7 +57,7 @@ class SteamSignIn():
         def RedirectUser(self, strPostData):
             logger.info('Invoked the fastapi RedirectUser!')
             response = RedirectResponse(
-                url=f"{self._provider}?{url}",
+                url=f"{self._provider}?{strPostData}",
                 status_code=303,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="steamsignin",
-    version="1.0.1",
+    version="1.1.0",
     author="TeddiO",
     author_email="",
     description="OpenID 2.0 sign in for Steam",


### PR DESCRIPTION
- Bump version from `1.0.1` to `1.1.0` to signify fastapi support.
- Change `url=f"{self._provider}?{url}"` to `url=f"{self._provider}?{strPostData}"`