### PR TITLE
Drop regex usage, tighten up against OpenID 2.0 spec & other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pySteamSignIn
-A small Python 3 class designed to get Steam OpenID 2 sign-in up and running as quick as possible.
+A lightweight Python 3 helper class for getting OpenID 2.0 Steam sign-in up and running quickly.
 
-There's not really any 'decent' Steam OpenID 2.0 libraries that give any proper documentation or insight in terms of how to actually use them. Alongside this they're often fairly bloated and problematic.
+There aren’t really any Steam-specific OpenID 2.0 sign-in libraries that provide clear documentation or insight into how the flow actually works. Most guidance instead points people at generic OpenID libraries, which are often overkill for Steam and fairly bloated in practice.
 
 As a result of this pySteamSignIn is designed to let you plug in Steam Auth as quick as possible and let you start returning results immediately.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Optional helper functions are provided for common web frameworks (Bottle, Flask,
 
 ## Finally
 
-Hopefully this helps someone out in terms of getting Steam OpenID and Python working in harmony. There's a few solutions for Flask and Django (which are basically glorified wrappers for python-openid) but both of them can still result in a fair few steps.
+Hopefully this helps someone get OpenID 2.0 Steam sign-in and Python working together a bit more smoothly. There's a few solutions for Flask and Django (which are basically glorified wrappers for python-openid) but both of them can still result in a fair few steps.
 
 This is based on OpenID 2.0 and **not** OpenID Connect / OAuth 2.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # pySteamSignIn
 A small Python 3 class designed to get Steam OpenID 2 sign-in up and running as quick as possible.
 
-As of this moment in time there's not really any 'decent' Steam Openid libraries that give any proper documentation or insight in terms of how to actually use them. Alongside this they're often fairly bloated and problematic. As a result of this pySteamSignIn is a lite class designed to let you plug in Steam Auth as quick as possible and let you start returning results immediately. 
+There's not really any 'decent' Steam OpenID 2.0 libraries that give any proper documentation or insight in terms of how to actually use them. Alongside this they're often fairly bloated and problematic.
+
+As a result of this pySteamSignIn is designed to let you plug in Steam Auth as quick as possible and let you start returning results immediately.
 
 ## Installation
 pySteamSignIn is now available on pip!
@@ -10,7 +12,7 @@ pySteamSignIn is now available on pip!
 
 ## Lets quickly get authentication rolling
 
-The power behind this is it provides the entire auth process over two (or three, if you're using bottlepy / Flask) functions.
+The power behind this is it provides the entire auth process over two (or three, if you're using bottlepy / Flask / FastAPI) functions.
 The first function is ConstructURL, which takes a string and returns a string
 
 The string to pass is whatever page the user is going to be sent back to as a result of logging in with Steam.
@@ -30,15 +32,14 @@ The important thing here is that you get thet GET returned data put into a  dict
 
 
 ```python
-#Some function where the data has been passed in a dictionary no less
+# Some function where the data has been passed in a dictionary no less
 steamLogin = SteamSignIn()
 returnedSteamID = steamLogin.ValidateResults(dictionaryGoesHere)
-#Perform checks to see if you actually have something that isn't false
+# Perform checks to see if you actually have something that isn't false
 ...
 ```
-And that's the general gist of it! At this point the user has been validated by Steam's own servers so the Steam64ID returned is one that can be trusted and you can use it to store information, you can set cookies on the current client and so on. 
-
-### If you use Bottlepy or Flask...
+And that's the general gist of it! At this point the user has been validated by Steam's own servers so the Steam64ID returned is one that can be trusted.
+### If you use Bottlepy, Flask or FastAPI...
 
 An additional helper function has been provided under the guise of RedirectUser.
 This will just relay the user on your behalf to the Steam site, as such 
@@ -46,7 +47,7 @@ This will just relay the user on your behalf to the Steam site, as such
 ```Python
 steamLogin = SteamSignIn()
 steamLogin.RedirectUser(steamLogin.ConstructURL('https://0.0.0.0:8080/processlogin'))
-# In the case of Flask, return the above RedirectUser call instead.
+# In the case of Flask / FastAPI, return the above RedirectUser call instead.
 ...
 ```
 
@@ -54,7 +55,7 @@ steamLogin.RedirectUser(steamLogin.ConstructURL('https://0.0.0.0:8080/processlog
 
 Hopefully this helps someone out in terms of getting Steam OpenID and Python working in harmony. There's a few solutions for Flask and Django (which are basically glorified wrappers for python-openid) but both of them can still result in a fair few steps.
 
-This is based on OpenID 2.0 and **not** OpenID Connect 1.0.
+This is based on OpenID 2.0 and **not** OpenID Connect / OAuth 2.
 
 If you require a Go version of this library, this is available [here](https://github.com/TeddiO/GoSteamAuth).
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ steamLogin.RedirectUser(steamLogin.ConstructURL('https://0.0.0.0:8080/processlog
 ...
 ```
 
+## Dependencies
+The core of pySteamSignIn uses only the Python standard library and does not depend on external HTTP clients such as requests.
+Optional helper functions are provided for common web frameworks (Bottle, Flask, FastAPI) and are only enabled if those frameworks are already installed.
+
 ## Finally
 
 Hopefully this helps someone out in terms of getting Steam OpenID and Python working in harmony. There's a few solutions for Flask and Django (which are basically glorified wrappers for python-openid) but both of them can still result in a fair few steps.

--- a/pysteamsignin/steamsignin.py
+++ b/pysteamsignin/steamsignin.py
@@ -115,7 +115,7 @@ class SteamSignIn():
         }
 
         # Basically, we split apart one of the args steam sends back only to send it back to them to validate!
-        # We also append check_authentication which tells OpenID 2.0 to actually validate what we send.
+        # We also append check_authentication which is required by the OpenID 2.0 spec to tell Valve to validate what we send.
         signedArgs = results['openid.signed'].split(',')
 
         for item in signedArgs:

--- a/pysteamsignin/steamsignin.py
+++ b/pysteamsignin/steamsignin.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import sys
 import urllib.request
 from urllib.parse import urlencode
@@ -34,6 +33,7 @@ else:
         'fastapi is not installed. Cannot use friendly RedirectUser helper function.'
     )
 
+OPENID_TIMEOUT = int(os.getenv('SSI_OPENID_TIMEOUT') or 15)
 
 class SteamSignIn():
     _provider = 'https://steamcommunity.com/openid/login'
@@ -63,7 +63,7 @@ class SteamSignIn():
             )
             return response
 
-    # This is the basic setup for getting steam to acknowledge our request for OpenID (2).
+    # This is the basic setup for getting steam to acknowledge our request for OpenID 2.0.
     # Our responseURL is where we want Steam to send us back to once the user has done something.
     # Returns a string that is safe to use via a POST.
     def ConstructURL(self, responseURL):
@@ -90,10 +90,23 @@ class SteamSignIn():
 
     # Takes a dictionary or a dict-like object.
     # This should be provided by whatever framework you're using with all the GET variables passed on.
-
     def ValidateResults(self, results):
 
         logger.info('Validating results of attempted log-in to Steam.')
+        required_fields = (
+            'openid.assoc_handle',
+            'openid.signed',
+            'openid.sig',
+            'openid.ns',
+            'openid.claimed_id',
+            'openid.identity',
+        )
+
+        for key in required_fields:
+            value = results.get(key)
+            if not isinstance(value, str) or not value:
+                return False
+
         validationArgs = {
             'openid.assoc_handle': results['openid.assoc_handle'],
             'openid.signed': results['openid.signed'],
@@ -102,30 +115,45 @@ class SteamSignIn():
         }
 
         # Basically, we split apart one of the args steam sends back only to send it back to them to validate!
-        # We also append check_authentication which tells OpenID2 to actually yknow, validate what we send.
+        # We also append check_authentication which tells OpenID 2.0 to actually validate what we send.
         signedArgs = results['openid.signed'].split(',')
 
         for item in signedArgs:
             itemArg = f'openid.{item}'
-            if results[itemArg] not in validationArgs:
-                validationArgs[itemArg] = results[itemArg]
+            value = results.get(itemArg)
+
+            if not isinstance(value, str) or not value:
+                return False
+
+            validationArgs[itemArg] = value
 
         validationArgs['openid.mode'] = 'check_authentication'
         parsedArgs = urlencode(validationArgs).encode("utf-8")
         logger.info('Encoded the validation arguments, prepped to send.')
 
-        with urllib.request.urlopen(self._provider, parsedArgs) as requestData:
+        with urllib.request.urlopen(self._provider, parsedArgs, timeout = OPENID_TIMEOUT) as requestData:
             responseData = requestData.read().decode('utf-8')
             logger.info(f"Sent request to {self._provider}, got back a response.")
 
+        fields = {}
+
+        for line in responseData.splitlines():
+            if ':' in line:
+                k, v = line.split(':', 1)
+                fields[k.strip()] = v.strip()
+
         # is_valid:true is what Steam returns if something is valid. The alternative is is_valid:false which obviously, is false.
-        if re.search('is_valid:true', responseData):
-            matched64ID = re.search('https://steamcommunity.com/openid/id/(\d+)', results['openid.claimed_id'])
-            if matched64ID != None or matched64ID.group(1) != None:
-                return matched64ID.group(1)
-            else:
-                # If we somehow fail to get a valid steam64ID, just return false
-                return False
-        else:
-            # Same again here
+        if fields.get('is_valid') != 'true':
             return False
+
+        claimed_id = results.get('openid.claimed_id')
+        identity = results.get('openid.identity')
+
+        if claimed_id != identity:
+            return False
+
+        prefix = 'https://steamcommunity.com/openid/id/'
+        if not claimed_id.startswith(prefix):
+            return False
+
+        return claimed_id[len(prefix):]

--- a/samples/fastapi-sample.py
+++ b/samples/fastapi-sample.py
@@ -13,7 +13,7 @@ app = FastAPI()
 def main(login = None):
 	if login != None:
 		steamLogin = SteamSignIn()
-		# Flask expects an explicit return on the route.
+		# FastAPI expects an explicit return on the route.
 		return steamLogin.RedirectUser(steamLogin.ConstructURL('http://localhost:8080/processlogin'))
 
 	return HTMLResponse('Click <a href="/?login=true">to log in</a>')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="steamsignin",
-    version="1.1.1",
+    version="1.1.2",
     author="TeddiO",
     author_email="",
     description="OpenID 2.0 sign in for Steam",


### PR DESCRIPTION
This update provides some internal changes, namely around trying to tighten things up against the OpenID 2.0 spec as well as better practises. No outward API changes are made and so users of this package should be able to upgrade without issue.

- Drop regex usage & remove `re` import.
- Added stricter validation for OpenID fields & to better follow the OpenID 2.0 spec.
- Added a default timeout for `urllib.request.urlopen` and defaulted to 15 seconds. This can be controlled by setting the env var `SSI_OPENID_TIMEOUT` .
- General documentation improvements.
- Bump to v`1.1.2`.
